### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # e621 'esix monitor' Artist Tag Monitor
 
-A Python-based monitoring system that tracks new posts on e621.net for specific artist tags, with a simple PHP interface.
+A Python-based monitoring system for Linux that tracks new posts on e621.net for specific artist tags, with a simple PHP interface.
 
 ![Logo](./preview.png?)
 
@@ -91,11 +91,10 @@ The monitor will work perfectly fine with a manually curated `artists.json` file
 1. **Ensure PHP has SQLite support**:
    ```bash
    # Check if PDO SQLite is installed
-   php -m | grep pdo
-   php -m | grep sqlite
-   
-   # Install if missing (Ubuntu/Debian)
-   sudo apt-get install php-sqlite3
+   if ! $(php -m | grep -E '^pdo$' >/dev/null) || ! $(php -m | grep -E '^sqlite$' >/dev/null); then
+      # Install if missing (Ubuntu/Debian)
+      sudo apt-get install php-sqlite3
+   fi
    ```
 
 ### Managing Artists


### PR DESCRIPTION
Specifies target system as Linux.
Changed the check if PDO SQLite is installed to auto-install dependency checking if required.
Updated the check to not provide false positives if a random module contains `pdo` in it's name (e.g. "swee**pdo**wn").

#### Note
I don't have PHP installed, so I couldn't check if the output of `-m` is correct (though I'm fairly confident it is).